### PR TITLE
fix(AV-1529): Update styling to front page search bar

### DIFF
--- a/src/less/components/forms.less
+++ b/src/less/components/forms.less
@@ -395,6 +395,11 @@ fieldset.checkboxes {
   }
 }
 
+// Frontpage search bar container
+.ytp-bg-highlight-base {
+  background-color: rgba(255, 255, 255, 0.3);
+}
+
 // Frontpage search bar input.
 .ytp-input-element-frontpage {
   .ytp-input-element;

--- a/src/less/components/layout.less
+++ b/src/less/components/layout.less
@@ -190,7 +190,17 @@ body {
 .suomifi-button-secondary-black-text {
   .suomifi-button-secondary;
 
+  font-family: @font-family-sans-serif;
   color: rgb(41, 41, 41);
+  border: solid 1px #c8cdd0;
+  font-weight: 400;
+  font-size: 18px;
+  padding-left: 10px;
+  padding-right: 10px;
+
+  span {
+    margin-right: 30px;
+  }
 
   i {
     margin-left: 8px;


### PR DESCRIPTION
Change the drop down border to have the same color as the search input box.

Change the font weight in the drop down.

Move the text and the chevron away from eachother in the drop down menu.

Change search input box background color and alpha.

Refs AV-1529