### PR TITLE
fix(AV-1664): Hide arrow box from guide page

### DIFF
--- a/src/less/drupal/overrides.less
+++ b/src/less/drupal/overrides.less
@@ -1242,6 +1242,7 @@ p:last-child,
   text-align: center;
   margin-top: 10px;
   margin-bottom: 20px;
+  display: none;
 
   h1 {
     margin: 0;


### PR DESCRIPTION
Hide arrowbox from guide page. It should be displayed only
when the menu is present.

Refs AV-1664