### PR TITLE
fix(AV-1666): Guide page next/prev link fix

### DIFF
--- a/src/less/drupal/guide.less
+++ b/src/less/drupal/guide.less
@@ -82,7 +82,7 @@
   a {
     color: rgb(255,255,255);
     text-decoration: underline;
-    flex-basis: 50%;
+    max-width: 50%;
     position: relative;
 
     i {


### PR DESCRIPTION
Remove the flex-basis attribue from the next/prev links since
it makes the links claim 50% of the space within the div.

Refs AV-1666