### PR TITLE
fix(AV-1650): Change arrowbox display attribute

### DIFF
--- a/src/less/drupal/overrides.less
+++ b/src/less/drupal/overrides.less
@@ -1242,7 +1242,6 @@ p:last-child,
   text-align: center;
   margin-top: 10px;
   margin-bottom: 20px;
-  display: none;
 
   h1 {
     margin: 0;


### PR DESCRIPTION
Given the changes in the "has_menu" function in the temaplate which
hides the arrowbox, this attribute is not needed anymore.

Refs AV-1650