### PR TITLE
fix(AV-1667): Guide page style fixes

### DIFF
--- a/src/less/drupal/overrides.less
+++ b/src/less/drupal/overrides.less
@@ -1240,7 +1240,6 @@ p:last-child,
   background: #2A6EBB;
   height: 125px;
   text-align: center;
-  margin-top: 10px;
   margin-bottom: 20px;
 
   h1 {
@@ -1250,7 +1249,7 @@ p:last-child,
     left: 50%;
     transform: translate(-50%, -50%);
     color: white;
-    font-weight: 500;
+    font-weight: 600;
   }
 }
 

--- a/src/less/navbars.less
+++ b/src/less/navbars.less
@@ -351,7 +351,6 @@ End of dropdown CSS
       padding-top: @padding-x__navigation;
       // Because border-bottom adds "padding" to bottom, subtract border-width from bottom padding
       padding-bottom: @padding-x__navigation - @border-width__navigation;
-      border-bottom: @border-width__navigation solid transparent;
 
       &.is-active {
         position: relative;

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -94,7 +94,7 @@
 @navbar-inverse-link-color: @opendata-brand-decorative;
 @navbar-color-background: @opendata-brand-primary;
 @navbar-color-links: @color--black;
-@navbar-height: 50px;
+@navbar-height: 67px;
 @navbar-responsive-toggle-background: #000;
 
 @infowell-color-dark: #175971;
@@ -134,7 +134,7 @@
 
 //Dropdown menu hover color that comes to the left border
 //used at least on Frontpage dropdown and guide page dropdown menu
-@menu-hover-border-color: #002e90;
+@menu-hover-border-color: #2A6EBB;
 
 @dataset-count-text-color: #c6c6c6;
 @organization-count-header-color: #c6c6c6;


### PR DESCRIPTION
Remove top padding from arrowbox so it is placed under the main menu.
Change the font weight of the text in the arrowbox to 600.

Change color of the hover styling on the menu items in the drop downs.
The entries in the drop down menus move a few pixels upwards when hovering over them,
remove the bottom border to fix this. This has a side effect on the main menu when no page is active
due to the minimum size of the main menu, change the main menu min-height to 67px.

Refs AV-1667